### PR TITLE
End YAML front matter at YAML document end markers

### DIFF
--- a/Syntaxes/Markdown (Front Matter).tmLanguage
+++ b/Syntaxes/Markdown (Front Matter).tmLanguage
@@ -18,7 +18,7 @@
 			<key>contentName</key>
 			<string>text.html.markdown.yaml</string>
 			<key>end</key>
-			<string>(^|\G)---\s*\n</string>
+			<string>(^|\G)(---|\.\.\.)\s*\n</string>
 			<key>name</key>
 			<string>markup.raw.block.yaml</string>
 			<key>patterns</key>


### PR DESCRIPTION
YAML documents can be ended with `...` markers.
This change adds support for them by ending the `source.yaml` include block.